### PR TITLE
Add functionality to toggle the display of the on-screen keyboard

### DIFF
--- a/Windows/Gopher/ConfigFile.cpp
+++ b/Windows/Gopher/ConfigFile.cpp
@@ -95,6 +95,7 @@ void ConfigFile::ExtractKeys()
 		outfile << "CONFIG_DISABLE = 0x0030		# Disables the Gopher" << std::endl;
 		outfile << "CONFIG_DISABLE_VIBRATION = 0x0011 # Disables Gopher Vibrations" << std::endl;
 		outfile << "CONFIG_SPEED_CHANGE =  0x0300	# Change speed" << std::endl;
+		outfile << "#CONFIG_OSK = 0x0020   # Toggle on-screen keyboard" << std::endl;
 		outfile << "\n" << std::endl;
 		outfile << "#	KEYBOARD SHORTCUTS ON CONTROLLER BUTTONS" << std::endl;
 		outfile << "#	SET 0 FOR NO FUNCTION" << std::endl;

--- a/Windows/Gopher/Gopher.cpp
+++ b/Windows/Gopher/Gopher.cpp
@@ -50,6 +50,7 @@ void Gopher::loadConfigFile()
 	CONFIG_DISABLE = strtol(cfg.getValueOfKey<std::string>("CONFIG_DISABLE").c_str(), 0, 0);
 	CONFIG_DISABLE_VIBRATION = strtol(cfg.getValueOfKey<std::string>("CONFIG_DISABLE_VIBRATION").c_str(), 0, 0);
 	CONFIG_SPEED_CHANGE = strtol(cfg.getValueOfKey<std::string>("CONFIG_SPEED_CHANGE").c_str(), 0, 0);
+	CONFIG_OSK = strtol(cfg.getValueOfKey<std::string>("CONFIG_OSK").c_str(), 0, 0);
 
 	//Controller bindings
 	GAMEPAD_DPAD_UP = strtol(cfg.getValueOfKey<std::string>("GAMEPAD_DPAD_UP").c_str(), 0, 0);
@@ -129,6 +130,29 @@ void Gopher::loop() {
 		if (_xboxClickIsDown[CONFIG_HIDE])
 		{
 			toggleWindowVisibility();
+		}
+	}
+
+	//Toggle the on-screen keyboard
+	if (CONFIG_OSK)
+	{
+		setXboxClickState(CONFIG_OSK);
+		if (_xboxClickIsDown[CONFIG_OSK])
+		{
+			// Get the otk window
+			HWND otk_win = getOskWindow();
+			if (otk_win == NULL)
+			{
+				printf("Please start the On-screen keyboard first\n");
+			}
+			else if(IsIconic(otk_win))
+			{
+				ShowWindow(otk_win, SW_RESTORE);
+			}
+			else
+			{
+				ShowWindow(otk_win, SW_MINIMIZE);
+			}
 		}
 	}
 
@@ -451,4 +475,23 @@ void Gopher::mapMouseClick(DWORD STATE, DWORD keyDown, DWORD keyUp)
 		mouseEvent(keyDown | keyUp);
 		mouseEvent(keyDown | keyUp);
 	}*/
+}
+
+static BOOL CALLBACK EnumWindowsProc(HWND curWnd, LPARAM lParam)
+{
+	TCHAR title[256];
+	if (GetWindowText(curWnd, title, 256) && !_tcscmp(title, _T("On-Screen Keyboard")))
+	{
+		*(HWND*)lParam = curWnd;
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+HWND Gopher::getOskWindow()
+{
+	HWND ret = NULL;
+	EnumWindows(EnumWindowsProc, (LPARAM)&ret);
+	return ret;
 }

--- a/Windows/Gopher/Gopher.h
+++ b/Windows/Gopher/Gopher.h
@@ -5,6 +5,8 @@
 #include <cmath> //for abs()
 #include <mmdeviceapi.h> //vol
 #include <endpointvolume.h> //vol
+#include <tchar.h>
+#include <ShlObj.h>
 
 #include <map>
 
@@ -49,6 +51,7 @@ private:
 	DWORD CONFIG_DISABLE = NULL;
 	DWORD CONFIG_DISABLE_VIBRATION = NULL;
 	DWORD CONFIG_SPEED_CHANGE = NULL;
+	DWORD CONFIG_OSK = NULL;
 
 	//Gamepad bindings
 	DWORD GAMEPAD_DPAD_UP = NULL;
@@ -112,4 +115,6 @@ public:
 	void mapMouseClick(DWORD STATE, DWORD keyDown, DWORD keyUp);
 
 	void setXboxClickState(DWORD state);
+
+	HWND getOskWindow();
 };


### PR DESCRIPTION
Allows a key to be bound (CONFIG_OTK) to toggle an already open On-Screen Keyboard (osk.exe) window between its normal and minimized state.